### PR TITLE
DB仕様書にお気に入りテーブルを追記しました

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -18,7 +18,7 @@ erDiagram
     Follow {
         id INT
         read_history_id INT
-        follow BOOLEAN
+        is_favorite BOOLEAN
     }
     ReadHistory ||--o{ Follow : "has"
 
@@ -37,4 +37,4 @@ erDiagram
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
 | read_history_id | 既読テーブル_ID | FK | FALSE | INT | ||
-| follow | お気に入り | | FALSE | Boolean |False||
+| is_favorite | お気に入り | | FALSE | BOOLEAN |False||

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -39,8 +39,8 @@ erDiagram
 | 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
-| book_id | 小説テーブル_ID | FK | FALSE | INT | ||
-| read_episode | 既読した話数 | | FALSE | INT | 0 ||
+| book_id | 小説テーブル_ID | FK | FALSE | INT | ||複合ユニーク|
+| read_episode | 既読した話数 | | FALSE | INT | 0 |複合ユニーク|
 
 ### Follow(お気に入りテーブル)
 | 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -10,31 +10,42 @@ prev: false
 
 ```mermaid
 erDiagram
+    Book {
+        id INT "ID"
+        ncode VARCHAR(255) "小説コード"
+    }
     ReadHistory {
-        id INT
-        ncode VARCHAR(255)
-        read_episode INT
+        id INT "ID"
+        book_id INT "小説テーブル_ID"
+        read_episode INT "既読した話数"
     }
     Follow {
-        id INT
-        read_history_id INT
-        is_follow BOOLEAN
+        id INT "ID"
+        book_id INT "小説テーブル_ID"
+        is_follow BOOLEAN "お気に入り"
     }
-    ReadHistory ||--o{ Follow : "has"
-
+    Book ||--o{ ReadHistory : "has"
+    Book ||--o{ Follow : "has"
 ```
 
 ## Table定義
-### ReadHistory(既読テーブル)
+### Book(小説テーブル)
 | 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
 | ncode | 小説コード | | FALSE | VARCHAR(255) |||
+
+
+### ReadHistory(既読テーブル)
+| 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
+| --- | --- | --- | --- | --- | --- | --- |
+| id | ID | PK | FALSE | INT | ||
+| book_id | 小説テーブル_ID | FK | FALSE | INT | ||
 | read_episode | 既読した話数 | | FALSE | INT | 0 ||
 
 ### Follow(お気に入りテーブル)
 | 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
-| read_history_id | 既読テーブル_ID | FK | FALSE | INT | ||
+| book_id | 小説テーブル_ID | FK | FALSE | INT | ||
 | is_follow | お気に入り | | FALSE | BOOLEAN |False||

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -10,16 +10,31 @@ prev: false
 
 ```mermaid
 erDiagram
-     ReadHistory {
+    ReadHistory {
         id INT
         ncode VARCHAR(255)
         read_episode INT
     }
+    Follow {
+        id INT
+        read_history_id INT
+        follow BOOLEAN
+    }
+    ReadHistory ||--o{ Follow : "has"
+
 ```
 
 ## Table定義
+### ReadHistory(既読テーブル)
 | 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
 | ncode | 小説コード | | FALSE | VARCHAR(255) |||
 | read_episode | 既読した話数 | | FALSE | INT | 0 ||
+
+### Follow(お気に入りテーブル)
+| 物理名 | 論理名 | PK/FK | NULL | データ型 |デフォルト| 備考|
+| --- | --- | --- | --- | --- | --- | --- |
+| id | ID | PK | FALSE | INT | ||
+| read_history_id | 既読テーブル_ID | FK | FALSE | INT | ||
+| follow | お気に入り | | FALSE | Boolean |False||

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -22,7 +22,6 @@ erDiagram
     Follow {
         id INT "ID"
         book_id INT "小説テーブル_ID"
-        is_follow BOOLEAN "お気に入り"
     }
     Book ||--o{ ReadHistory : "has"
     Book ||--o{ Follow : "has"
@@ -48,4 +47,3 @@ erDiagram
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
 | book_id | 小説テーブル_ID | FK | FALSE | INT | ||
-| is_follow | お気に入り | | FALSE | BOOLEAN |False||

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -18,7 +18,7 @@ erDiagram
     Follow {
         id INT
         read_history_id INT
-        is_favorite BOOLEAN
+        is_follow BOOLEAN
     }
     ReadHistory ||--o{ Follow : "has"
 
@@ -37,4 +37,4 @@ erDiagram
 | --- | --- | --- | --- | --- | --- | --- |
 | id | ID | PK | FALSE | INT | ||
 | read_history_id | 既読テーブル_ID | FK | FALSE | INT | ||
-| is_favorite | お気に入り | | FALSE | BOOLEAN |False||
+| is_follow | お気に入り | | FALSE | BOOLEAN |False||


### PR DESCRIPTION
DB仕様書にお気に入りテーブルを追記しました。

ローカル環境で正常に表示できることを確認しています。
<img width="616" alt="スクリーンショット 2024-02-21 18 57 42" src="https://github.com/watame/mobile_web_novel_reader/assets/103478594/87bda8f0-e2a1-4a4e-9245-578affc399a4">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
	- 新しいエンティティ`Follow`を追加し、`id`と`book_id`フィールドを設定しました。
	- `Book`と`ReadHistory`、`Book`と`Follow`エンティティ間の関係を確立しました。
	- `Book`、`ReadHistory`、`Follow`のテーブル定義を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->